### PR TITLE
Update lighttpd for 16.0

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,3 +1,24 @@
+turnkey-lighttpd-php-fastcgi-16.0 (1) turnkey; urgency=low
+
+  * Explcitly disable TLS<1.2 (i.e. SSLv3, TLSv1, TLSv1.1). (v15.x
+    TurnKey releases supported TLS 1.2, but could fallback as low as TLSv1).
+
+  * Update SSL/TLS cyphers to provide "Intermediate" browser/client support
+    (suitable for "General-purpose servers with a variety of clients,
+    recommended for almost all systems"). As provided by Mozilla via
+    https://ssl-config.mozilla.org/.
+
+  * Updated all relevant Debian packages to Buster/10 versions; including
+    PHP 7.3.
+
+  * Updated version of mysqltuner script - now installed as per upstream
+    recommendation.
+
+  * Note: Please refer to turnkey-core's changelog for changes common to all
+    appliances. Here we only describe changes specific to this appliance.
+
+ -- Stefan Davis <stefan@turnkeylinux.org>  Mon, 15 Jun 2020 15:31:40 +1000
+
 turnkey-lighttpd-php-fastcgi-15.1 (1) turnkey; urgency=low
 
   * Rebuild to resolve inadvertant removal of mariadb during sec-updates

--- a/conf.d/main
+++ b/conf.d/main
@@ -3,3 +3,5 @@
 # enable webroot
 lighty-enable-mod webroot
 
+# ensure mod_openssl is loaded
+sed -i '/^server\.modules = / a"mod_openssl",' /etc/lighttpd/lighttpd.conf

--- a/plan/main
+++ b/plan/main
@@ -9,7 +9,7 @@ php-curl
 php-mysql
 webmin-phpini
 
-mysql-server
+default-mysql-server
 webmin-mysql
 adminer
 


### PR DESCRIPTION
- Update everything for buster
- Ensure mod_openssl is explicitly loaded (this doesn't matter currently, but in future releases mod_openssl will not be automatically loaded)

https://github.com/turnkeylinux/common/pull/155 is also relevant to the 16.0 update for lighttpd